### PR TITLE
corrected redirect for an empty path

### DIFF
--- a/outreach-mapping-solutions-FE/src/app/app-routing.module.ts
+++ b/outreach-mapping-solutions-FE/src/app/app-routing.module.ts
@@ -15,7 +15,7 @@ import { ClientProfileAssessmentsComponent } from './portals/client-portal/clien
 import { ClientProfileCaseNotesComponent } from './portals/client-portal/client-profile/client-profile-case-notes/client-profile-case-notes.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: '/portal', pathMatch:'full'},
+  { path: '', redirectTo: '/client-portal/search', pathMatch:'full'},
 
   { path: 'client-portal', redirectTo: '/client-portal/search', pathMatch:'full'},
 


### PR DESCRIPTION
Updated app-routing.module.ts to correctly redirect to client-portal/search when given an empty path